### PR TITLE
Add local Docker Compose workflow and ARM-friendly Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,20 @@ FROM buildpack-deps:bookworm
 ARG SUNRISER_UID="1000"
 ARG SUNRISER_GID="1000"
 
-ENV SUNRISER_UID ${SUNRISER_UID}
-ENV SUNRISER_GID ${SUNRISER_GID}
+ENV SUNRISER_UID=${SUNRISER_UID}
+ENV SUNRISER_GID=${SUNRISER_GID}
 
 # Install Debian packages ----------------------------------------------------
 
-ENV DEBIAN_FRONTEND  "noninteractive"
+ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" > /debconf-preseed.txt \
   && echo "locales locales/default_environment_locale select en_US.UTF-8" >> /debconf-preseed.txt \
   && debconf-set-selections /debconf-preseed.txt && apt-get update -y \
   && apt-get install -y git zip unzip bzip2 ca-certificates hostname wget \
     build-essential libssl-dev zlib1g-dev locales apt-utils curl libcdb-dev \
-    libev-dev cmake python3 python-is-python3 libc6-i386 openocd \
-    gdb-multiarch moreutils \
+    libev-dev cmake python3 python-is-python3 openocd gdb-multiarch moreutils \
+  && if [ "$(dpkg --print-architecture)" = "amd64" ]; then apt-get install -y libc6-i386; fi \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/* /var/cache/*
 
 WORKDIR /usr/src
@@ -28,12 +28,12 @@ RUN wget -O gcc-arm-none-eabi-4_9-2014q4-20141203-linux.tar.bz2 \
   && tar xvjf gcc-arm-none-eabi-4_9-2014q4-20141203-linux.tar.bz2 \
   && rm gcc-arm-none-eabi-4_9-2014q4-20141203-linux.tar.bz2
 
-ENV PATH          "/usr/src/gcc-arm-none-eabi-4_9-2014q4/bin:${PATH}"
+ENV PATH="/usr/src/gcc-arm-none-eabi-4_9-2014q4/bin:${PATH}"
 
 # Install Perl -------------------------------------------------------------
 
-ENV PERL_VERSION  "5.38.2"
-ENV PERL_SHA256   "a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e"
+ENV PERL_VERSION="5.38.2"
+ENV PERL_SHA256="a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e"
 
 RUN mkdir -p /usr/src/perl && cd /usr/src/perl \
   && curl -sfSLO https://www.cpan.org/src/5.0/perl-${PERL_VERSION}.tar.gz \
@@ -53,7 +53,7 @@ COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 
 # Install SunRiser User ------------------------------------------------------------
 
-ENV SUNRISER_PROJECT_ROOT  "/opt/sunriser"
+ENV SUNRISER_PROJECT_ROOT="/opt/sunriser"
 
 RUN mkdir /home/sunriser \
   && groupadd -g ${SUNRISER_GID} sunriser \
@@ -69,12 +69,12 @@ WORKDIR ${SUNRISER_PROJECT_ROOT}/src
 
 # Install Perl Modules --------------------------------------------------------
 
-ENV PATH                 "${SUNRISER_PROJECT_ROOT}/install/perl5/bin:${PATH}"
-ENV PERL5LIB             "${SUNRISER_PROJECT_ROOT}/install/perl5/lib/perl5"
-ENV PERL_LOCAL_LIB_ROOT  "${SUNRISER_PROJECT_ROOT}/install/perl5"
-ENV PERL_MB_OPT          "--install_base ${SUNRISER_PROJECT_ROOT}/install/perl5"
-ENV PERL_MM_OPT          "INSTALL_BASE=${SUNRISER_PROJECT_ROOT}/install/perl5"
-ENV PERL_CARTON_PATH     "${SUNRISER_PROJECT_ROOT}/install/perl5"
+ENV PATH="${SUNRISER_PROJECT_ROOT}/install/perl5/bin:${PATH}"
+ENV PERL5LIB="${SUNRISER_PROJECT_ROOT}/install/perl5/lib/perl5"
+ENV PERL_LOCAL_LIB_ROOT="${SUNRISER_PROJECT_ROOT}/install/perl5"
+ENV PERL_MB_OPT="--install_base ${SUNRISER_PROJECT_ROOT}/install/perl5"
+ENV PERL_MM_OPT="INSTALL_BASE=${SUNRISER_PROJECT_ROOT}/install/perl5"
+ENV PERL_CARTON_PATH="${SUNRISER_PROJECT_ROOT}/install/perl5"
 
 COPY --chown=${SUNRISER_UID}:${SUNRISER_GID} ./docker ${SUNRISER_PROJECT_ROOT}/src/docker
 
@@ -91,6 +91,6 @@ COPY --chown=${SUNRISER_UID}:${SUNRISER_GID} . ${SUNRISER_PROJECT_ROOT}/src
 
 # Add project path ------------------------------------------------------------
 
-ENV PATH           "${SUNRISER_PROJECT_ROOT}/src/bin:${PATH}"
+ENV PATH="${SUNRISER_PROJECT_ROOT}/src/bin:${PATH}"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ cd sunriser
 perl -I$HOME/perl5/lib/perl5 -Mlocal::lib bin/sunriser_simulator
 ```
 
+Docker
+======
+
+Zum lokalen Starten mit Docker:
+
+```bash
+cd sunriser
+docker compose up --build -d
+```
+
+Danach ist der Simulator unter <http://localhost:9000> erreichbar.
+
+Zum Stoppen und Aufräumen:
+
+```bash
+docker compose down
+```
+
 Microcontroller Software
 ========================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  sunriser:
+    container_name: sunriser
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SUNRISER_UID: "${SUNRISER_UID:-1000}"
+        SUNRISER_GID: "${SUNRISER_GID:-1000}"
+    command: ["bin/sunriser_simulator", "--port", "9000"]
+    ports:
+      - "9000:9000"
+    volumes:
+      - ./config:/opt/sunriser/src/config
+    restart: unless-stopped
+    init: true


### PR DESCRIPTION
## Summary

This PR makes the local Docker workflow easier to use and improves compatibility on Apple Silicon Macs.

## Changes

- add a simple `docker-compose.yml` for running the simulator locally
- document the Docker workflow in `README.md`
- update `Dockerfile` to use `ENV key=value` format
- only install `libc6-i386` on `amd64`, so the image builds on Apple Silicon or any other ARM device

## Notes

- this is intended to improve the local simulator workflow

## How To Test

```bash
cd sunriser
docker compose up --build -d
curl http://localhost:9000
docker compose down
```