### PR TITLE
fix: omit timewarp from /state when inactive, matching real device

### DIFF
--- a/lib/SunRiser/Simulator.pm
+++ b/lib/SunRiser/Simulator.pm
@@ -185,7 +185,6 @@ sub state {
     tick => ( ( $time - $self->start_time ) * 1000 ),
     logsize => 0,
     errsize => 1000,
-    timewarp => 0,
     # PWM name is a number but must be treated like a string
     pwms => { map { $_."", ( int(rand(21)) * 50 ) } 1..$pwms },
     sensors => {
@@ -501,9 +500,17 @@ sub set_timewarp {
     if (!defined $env->{'psgix.session'}->{state}) {
       $env->{'psgix.session'}->{state} = $self->state;
     }
-    $env->{'psgix.session'}->{state}->{timewarp} = $value;
+    if ($value) {
+      $env->{'psgix.session'}->{state}->{timewarp} = $value;
+    } else {
+      delete $env->{'psgix.session'}->{state}->{timewarp};
+    }
   } else {
-    $self->state->{timewarp} = $value;
+    if ($value) {
+      $self->state->{timewarp} = $value;
+    } else {
+      delete $self->state->{timewarp};
+    }
   }
 }
 


### PR DESCRIPTION
Whilst working on my plugin for the device I have noticed the simulator is incorrect for a few different behaviours.

## Changes

### `timewarp` omitted from `/state` when inactive

On the real device, the `timewarp` key is **absent** from the `/state` response when time-lapse mode is off. The simulator was always including `timewarp: 0`, which does not match this behaviour.